### PR TITLE
flip boot pin default state

### DIFF
--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -122,7 +122,7 @@ static void timers_init(void)
  */
 static void gpio_init(void)
 {
-    nrf_gpio_cfg_input(BOOTLOADER_GPIO_PIN, NRF_GPIO_PIN_PULLDOWN);
+    nrf_gpio_cfg_input(BOOTLOADER_GPIO_PIN, NRF_GPIO_PIN_PULLUP);
 }
 
 


### PR DESCRIPTION
I modified the initialization for the boot pin by changing the input resistance from pull-down to pull-up.  This in effect will flip the default state of the device so that it will boot up into the application and not into the bootloader.  To boot up into the bootloader, the user will need to ground the boot pin prior to powering up the device.